### PR TITLE
Fix `Scrollbar Options` controller folder toggling(demo page)

### DIFF
--- a/test/scripts/controller.js
+++ b/test/scripts/controller.js
@@ -46,7 +46,7 @@ const boolMap = {
 
 const scrollbars = Scrollbar.initAll(options);
 const controller = new dat.GUI();
-controller.addFolder('Scrollbar Options');
+const scrollbarCtrl = controller.addFolder('Scrollbar Options');
 document.getElementById('controller').appendChild(controller.domElement);
 
 let updateScrollbar = () => scrollbars.forEach((s) => s.setOptions(options));
@@ -60,17 +60,17 @@ Object.keys(options).forEach((prop) => {
         const limit = optionLimit[prop];
 
         if (limit.type === 'range') {
-            ctrl = controller.add(options, prop, ...limit.value);
+            ctrl = scrollbarCtrl.add(options, prop, ...limit.value);
         }
 
         if (limit.type === 'select') {
-            ctrl = controller.add(options, prop, limit.value);
+            ctrl = scrollbarCtrl.add(options, prop, limit.value);
         }
     } else {
         if (prop === 'overscrollEffectColor') {
-            ctrl = controller.addColor(options, prop);
+            ctrl = scrollbarCtrl.addColor(options, prop);
         } else {
-            ctrl = controller.add(options, prop);
+            ctrl = scrollbarCtrl.add(options, prop);
         }
     }
 

--- a/test/styles/index.styl
+++ b/test/styles/index.styl
@@ -175,7 +175,21 @@ footer
   .property-name
     width: 60% !important
 
-  :not(.closed) li.color
+  // the selector `.dg :not(.closed) li.color` won't work here,
+  // because the DOM structure is similar like this:
+  //
+  // div.dg.main
+  //   ul (or: ul.closed)
+  //     li.folder
+  //       div.dg
+  //         ul (or: ul.closed)
+  //           li.color
+  //
+  // so `.dg :not(.closed) li.color` will always select the color option
+  // no matter folder is opened or closed.
+  //
+  // so we need to add `.folder .dg` restriction.
+  .folder .dg :not(.closed) li.color
     overflow: visible !important
   .c
     position: relative
@@ -225,5 +239,3 @@ footer
   border: 3px solid #ccc
   box-sizing: border-box
   cursor: ew-resize
-
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix `Scrollbar Options` controller folder toggling on demo page.

## Description
<!--- Describe your changes in detail -->

`Scrollbar Options` controller toggling is not working now,because it add options to root dat controller directly, rather than add to the created folder.

### Before Fixed:

![smooth-scrollbar-controller-bug](https://cloud.githubusercontent.com/assets/6076919/19352804/ca0457c2-9193-11e6-9b27-09347b07fe59.gif)


### After Fixed:

![fixed-smooth-scrollbar-controller-bug](https://cloud.githubusercontent.com/assets/6076919/19352809/ce31a8c2-9193-11e6-8734-6d80082a9a0f.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
