### PR TITLE
doc(readme): scrollIntoView remove extra semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ Scrolls the target element into visible area of scrollbar, like DOM method [`ele
 scrollbar.scrollIntoView(document.getElementById('a-section'), {
     offsetTop: 12,
     offsetLeft: 34,
-    onlyScrollIfNeeded: true,
+    onlyScrollIfNeeded: true
 });
 ```
 


### PR DESCRIPTION
Remove extra semicolon in example

## Description
Options provided to scrollIntoView method contain an unnecessary semicolon at the end.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
