### PR TITLE
feat: add `alignToTop` option for scroll-into-view

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ scrollbar.scrollIntoView(elem, options?): void
 | :-------: | :--: | :-----: | :---------- |
 | `alignToTop` | boolean | `true` | Whether to align to the top or the bottom edge of container. |
 | `offsetTop` | number | `0` | Offset to top edge of container (used only if alignToTop is true). |
-| `offsetLeft` | number | `0` | Offset to left edge of container (used only if alignToTop is true). |
+| `offsetLeft` | number | `0` | Offset to left edge of container. |
 | `offsetBottom` | number | `0` | Offset to bottom edge of container (used only if alignToTop is false). |
 | `onlyScrollIfNeeded` | boolean | `false` | Whether to scroll container when target element is visible. |
 

--- a/README.md
+++ b/README.md
@@ -494,8 +494,10 @@ scrollbar.scrollIntoView(elem, options?): void
 
 | Property | type | default | description |
 | :-------: | :--: | :-----: | :---------- |
-| `offsetTop` | number | `0` | Offset to top edge of container. |
-| `offsetLeft` | number | `0` | Offset to left edge of container. |
+| `alignToTop` | boolean | `true` | Whether to align to the top or the bottom edge of container. |
+| `offsetTop` | number | `0` | Offset to top edge of container (used only if alignToTop is true). |
+| `offsetLeft` | number | `0` | Offset to left edge of container (used only if alignToTop is true). |
+| `offsetBottom` | number | `0` | Offset to bottom edge of container (used only if alignToTop is false). |
 | `onlyScrollIfNeeded` | boolean | `false` | Whether to scroll container when target element is visible. |
 
 Scrolls the target element into visible area of scrollbar, like DOM method [`element.scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView). This will be helpful when you want to create some anchors.

--- a/src/apis/scroll-into-view.js
+++ b/src/apis/scroll-into-view.js
@@ -11,16 +11,20 @@ import { SmoothScrollbar } from '../smooth-scrollbar';
  * Scroll target element into visible area of scrollbar.
  *
  * @param  {Element} target                      target element
+ * @param  {Boolean} options.alignToTop          whether to align to the top or the bottom edge of container
  * @param  {Boolean} options.onlyScrollIfNeeded  whether scroll container when target element is visible
  * @param  {Number}  options.offsetTop           scrolling stop offset to top
  * @param  {Number}  options.offsetLeft          scrolling stop offset to left
+ * @param  {Number}  options.offsetBottom        scrolling stop offset to bottom
  */
 SmoothScrollbar.prototype.scrollIntoView = function (
     elem,
     {
+        alignToTop = true,
         onlyScrollIfNeeded = false,
         offsetTop = 0,
         offsetLeft = 0,
+        offsetBottom = 0,
     } = {}
 ) {
     const { targets, bounding } = this;
@@ -33,6 +37,6 @@ SmoothScrollbar.prototype.scrollIntoView = function (
 
     this.__setMovement(
         targetBounding.left - bounding.left - offsetLeft,
-        targetBounding.top - bounding.top - offsetTop,
+        alignToTop ? targetBounding.top - bounding.top - offsetTop : targetBounding.bottom - bounding.bottom - offsetBottom,
     );
 };


### PR DESCRIPTION
Implements the same behavior [Element.scrollIntoView](https://developer.mozilla.org/en/docs/Web/API/Element/scrollIntoView)'s alignToTop does: aligns the target element to the bottom edge of the container

## Description
I am writing a list-based component where you can select the next element with keyboard's down key. 

Originally I used the browser provided [Element.scrollIntoView](https://developer.mozilla.org/en/docs/Web/API/Element/scrollIntoView) to scroll the element into the view: if the newly selected element was above the visible container, then I used `alignToTop = true` to scroll the element into view and aligning it to the top of the container. Otherwise if the element was below the visible space then I scrolled to the bottom using `alignToTop = false`. This is the standard behavior for listbox-like controls.

I really like your component, so I started using it as part of my project, but this behavior was missing for me, so I implemented it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I am not sure about the project's contributing guidelines, so please feel free to tell me if anything else is need for the PR being accepted. Thanks!

Edit: I added a JSBin where the new functionality can be tried out: http://output.jsbin.com/saduled/edit