### PR TITLE
[7.3.0] Fixed destroy in IE 11

### DIFF
--- a/src/apis/destroy.js
+++ b/src/apis/destroy.js
@@ -65,7 +65,9 @@ SmoothScrollbar.prototype.destroy = function (isRemoval) {
         // reset content
         const childNodes = [...content.childNodes];
 
-        container.innerHTML = '';
+        while (container.firstChild) {
+            container.removeChild(container.firstChild);
+        }
 
         childNodes.forEach((el) => container.appendChild(el));
     });


### PR DESCRIPTION
## Description
Replaced the deletion of innerHTML with a loop, cause the deletion would also empty the content of the saved elements in IE, which resulted in empty DOM after the destruction of the Scrollbar element.

Maybe there's a better way to do it, but this restores functionality in IE10/11.

Last but not least, SCREW IE!