### PR TITLE
Fix mousewheel eventname on IE11<=

### DIFF
--- a/scripts/webpack.base.js
+++ b/scripts/webpack.base.js
@@ -32,7 +32,7 @@ module.exports = {
     new webpack.DefinePlugin({
       __SCROLLBAR_VERSION__: JSON.stringify(
         process.env.SCROLLBAR_VERSION || require('../package.json').version
-      )
+      ),
     }),
     new CircularDependencyPlugin({
       exclude: /node_modules/,

--- a/src/events/wheel.ts
+++ b/src/events/wheel.ts
@@ -17,8 +17,9 @@ export function wheelHandler(scrollbar: I.Scrollbar) {
   const addEvent = eventScope(scrollbar);
 
   const target = scrollbar.options.wheelEventTarget || scrollbar.containerEl;
+  const eventName = 'onwheel' in window || document.implementation.hasFeature('Events.wheel', '3.0') ? 'wheel' : 'mousewheel';
 
-  addEvent(target, 'onwheel' in window ? 'wheel' : 'mousewheel', (evt: WheelEvent) => {
+  addEvent(target, eventName, (evt: WheelEvent) => {
     const { x, y } = normalizeDelta(evt);
 
     scrollbar.addTransformableMomentum(x, y, evt, (willScroll) => {


### PR DESCRIPTION
## Description
The only way to test support for the wheel event in IE9+ is check the feature `Events.wheel` on the `document.implementation.hasFeature` object, instead of `window`. ([see here](https://github.com/basilfx/normalize-wheel/blob/a1b69f0096ee4fca1436241e493f7d7919242cc7/src/isEventSupported.js#L56))

Without this test, the eventname on IE11< is `mousewheel`, instead of `wheel`:
`const eventName = 'onwheel' in window ? 'wheel' : 'mousewheel' // mousewheel ❌`
`const eventName = 'onwheel' in window || document.implementation.hasFeature('Events.wheel', '3.0') ? 'wheel' : 'mousewheel' // wheel 👍`

Using `wheel` event, wheel data on IE11< is more similar than other browser, with benefit for the user experience.

The package `normalize wheel` normalize data across browsers and OS in a more accurate way.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)