### PR TITLE
Improve `tab-index` accessibility

### DIFF
--- a/src/events/keyboard.ts
+++ b/src/events/keyboard.ts
@@ -21,7 +21,13 @@ export function keyboardHandler(scrollbar: I.Scrollbar) {
   const container = scrollbar.containerEl;
 
   addEvent(container, 'keydown', (evt: KeyboardEvent) => {
-    if (document.activeElement !== container) {
+    const { activeElement } = document;
+
+    if (activeElement !== container && !container.contains(activeElement)) {
+      return;
+    }
+
+    if (isEditable(activeElement)) {
       return;
     }
 
@@ -76,4 +82,20 @@ function getKeyDelta(scrollbar: I.Scrollbar, keyCode: number) {
     default:
       return null;
   }
+}
+
+function isEditable(elem: any): boolean {
+  if (elem.tagName === 'INPUT' || elem.tagName === 'TEXTAREA') {
+    return true;
+  }
+
+  while (elem) {
+    if (elem.contentEditable === 'true') {
+      return true;
+    }
+
+    elem = elem.parentElement;
+  }
+
+  return false;
 }

--- a/src/events/keyboard.ts
+++ b/src/events/keyboard.ts
@@ -5,6 +5,7 @@ import {
 } from '../utils/';
 
 enum KEY_CODE {
+  TAB = 9,
   SPACE = 32,
   PAGE_UP,
   PAGE_DOWN,
@@ -61,6 +62,8 @@ function getKeyDelta(scrollbar: I.Scrollbar, keyCode: number) {
   } = scrollbar;
 
   switch (keyCode) {
+    case KEY_CODE.TAB:
+      return handleTabKey(scrollbar);
     case KEY_CODE.SPACE:
       return [0, 200];
     case KEY_CODE.PAGE_UP:
@@ -82,6 +85,16 @@ function getKeyDelta(scrollbar: I.Scrollbar, keyCode: number) {
     default:
       return null;
   }
+}
+
+function handleTabKey(scrollbar: I.Scrollbar) {
+  // handle in next frame
+  requestAnimationFrame(() => {
+    scrollbar.scrollIntoView(document.activeElement as HTMLElement, {
+      offsetTop: scrollbar.size.container.height / 2,
+      onlyScrollIfNeeded: true,
+    });
+  });
 }
 
 function isEditable(elem: any): boolean {

--- a/src/events/keyboard.ts
+++ b/src/events/keyboard.ts
@@ -99,15 +99,7 @@ function handleTabKey(scrollbar: I.Scrollbar) {
 
 function isEditable(elem: any): boolean {
   if (elem.tagName === 'INPUT' || elem.tagName === 'TEXTAREA') {
-    return true;
-  }
-
-  while (elem) {
-    if (elem.contentEditable === 'true') {
-      return true;
-    }
-
-    elem = elem.parentElement;
+    return !elem.disabled;
   }
 
   return false;

--- a/src/scrollbar.ts
+++ b/src/scrollbar.ts
@@ -147,7 +147,7 @@ export class Scrollbar implements I.Scrollbar {
     containerEl.setAttribute('data-scrollbar', 'true');
 
     // make container focusable
-    containerEl.setAttribute('tabindex', '1');
+    containerEl.setAttribute('tabindex', '-1');
     setStyle(containerEl, {
       overflow: 'hidden',
       outline: 'none',


### PR DESCRIPTION
## Description

See details in #152.

This PR improves accessibility by

1. setting `tabindex` to `-1` to make the scrollbar focusable with mouse clicking,  while removing it from natural tab order so it will never be focused by pressing <kbd>tab</kbd> key,

2. enabling scrolling on <kbd>tab</kbd> navigation (scroll-into-view when focused element/link changes) 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

ping @Hongbo-Miao
