### PR TITLE
fixed wheelEventTarget warning

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -54,8 +54,9 @@ export class Options {
   }
 
   set wheelEventTarget(el: EventTarget | null) {
-    console.warn('[smooth-scrollbar]: `options.wheelEventTarget` is deprecated and will be removed in the future, use `options.delegateTo` instead.');
-
+   if(el){
+       console.warn('[smooth-scrollbar]: `options.wheelEventTarget` is deprecated and will be removed in the future, use `options.delegateTo` instead.');
+    }
     this.delegateTo = el;
   }
 


### PR DESCRIPTION
Show wheelEventTarget deprecation warning only if EventTarget exists.

## Description
console warning wrapped in if statement to prevent logging warning if wheelEventTarget is null.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
