### PR TITLE
Improved keyboard scrolling

### DIFF
--- a/src/events/keyboard.ts
+++ b/src/events/keyboard.ts
@@ -99,6 +99,7 @@ function handleTabKey(scrollbar: I.Scrollbar) {
 
 function isEditable(elem: any): boolean {
   if (elem.tagName === 'INPUT' ||
+      elem.tagName === 'SELECT' ||
       elem.tagName === 'TEXTAREA' ||
       elem.isContentEditable) {
     return !elem.disabled;


### PR DESCRIPTION
Prevent UP, DOWN key to scroll page instead of switch options on select field.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If you tab through elements the option change of an select element via keyboards up and down key would scroll the page instead of change the select options.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
