### PR TITLE
Support for SHIFT + Scroll

### DIFF
--- a/src/events/keyboard.ts
+++ b/src/events/keyboard.ts
@@ -21,6 +21,20 @@ export function keyboardHandler(scrollbar: I.Scrollbar) {
   const addEvent = eventScope(scrollbar);
   const container = scrollbar.containerEl;
 
+  if (scrollbar.options.horizontalScrollWithShift) {
+    addEventListener('keydown', (evt: KeyboardEvent) => {
+      if (evt.key === 'Shift') {
+        scrollbar.horizontalMode = true;
+      }
+    });
+
+    addEventListener('keyup', (evt: KeyboardEvent) => {
+      if (evt.key === 'Shift') {
+        scrollbar.horizontalMode = false;
+      }
+    });
+  }
+
   addEvent(container, 'keydown', (evt: KeyboardEvent) => {
     const { activeElement } = document;
 

--- a/src/events/wheel.ts
+++ b/src/events/wheel.ts
@@ -12,7 +12,13 @@ export function wheelHandler(scrollbar: I.Scrollbar) {
   const eventName = ('onwheel' in window || document.implementation.hasFeature('Events.wheel', '3.0')) ? 'wheel' : 'mousewheel';
 
   addEvent(target, eventName, (evt: WheelEvent) => {
-    const { x, y } = normalizeDelta(evt);
+    let { x, y } = normalizeDelta(evt);
+
+    if (scrollbar.options.horizontalScrollWithShift) {
+      if (scrollbar.horizontalMode) {
+        [x, y] = [y, x];
+      }
+    }
 
     scrollbar.addTransformableMomentum(x, y, evt, (willScroll) => {
       if (willScroll) {

--- a/src/interfaces/scrollbar.ts
+++ b/src/interfaces/scrollbar.ts
@@ -11,6 +11,7 @@ export type ScrollbarOptions = {
   renderByPixels: boolean,
   alwaysShowTracks: boolean,
   continuousScrolling: boolean,
+  horizontalScrollWithShift: boolean,
   delegateTo: EventTarget | null,
   wheelEventTarget: EventTarget | null,
   plugins: any,
@@ -79,6 +80,8 @@ export interface Scrollbar {
   readonly track: TrackController;
 
   readonly options: ScrollbarOptions;
+
+  horizontalMode: boolean;
 
   bounding: ScrollbarBounding;
   size: ScrollbarSize;

--- a/src/options.ts
+++ b/src/options.ts
@@ -43,6 +43,13 @@ export class Options {
   continuousScrolling = true;
 
   /**
+   * Set to `true` to support horizontal scroll
+   * by holding Shift + mouse wheel
+   */
+  @boolean
+  horizontalScrollWithShift = false;
+
+  /**
    * Delegate wheel events and touch events to the given element.
    * By default, the container element is used.
    * This option will be useful for dealing with fixed elements.

--- a/src/scrollbar.ts
+++ b/src/scrollbar.ts
@@ -58,6 +58,11 @@ export class Scrollbar implements I.Scrollbar {
   readonly contentEl: HTMLElement;
 
   /**
+   * Indicates if user is holding shift and should scroll horizontally (if enabled)
+   */
+  horizontalMode: boolean;
+
+  /**
    * Geometry infomation for current scrollbar instance
    */
   size: I.ScrollbarSize;


### PR DESCRIPTION
## Description
Many people use Shift + scroll but it doesn't work with this custom scrolling bar. These changes will allow to listen for keys (keydown and keyup events) and scroll horizontally while the shift button is held down.
This however comes with a downside: If a use is holding shift and click on another window, the browser will still think shift is held down (because keyup is never triggered), and it will horizontally scroll even when shift is not held down. I don't think this will often happen, and all the user will have to do is hold shift again and release it, to reset it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
