### PR TITLE
fix(event/select): prevent scrolling when context menu opened

### DIFF
--- a/src/events/select.ts
+++ b/src/events/select.ts
@@ -45,6 +45,12 @@ export function selectHandler(scrollbar: I.Scrollbar) {
     isContextMenuOpened = true;
   });
 
+  // reset context menu flag on mouse down
+  // to ensure the scrolling is allowed in the next selection
+  addEvent(contentEl, 'mousedown', () => {
+    isContextMenuOpened = false;
+  });
+
   addEvent(contentEl, 'selectstart', () => {
     if (isContextMenuOpened) {
       return;

--- a/src/events/select.ts
+++ b/src/events/select.ts
@@ -11,6 +11,7 @@ export function selectHandler(scrollbar: I.Scrollbar) {
   const { containerEl, contentEl } = scrollbar;
 
   let isSelected = false;
+  let isContextMenuOpened = false; // flag to prevent selection when context menu is opened
   let animationID: number;
 
   function scroll({ x, y }) {
@@ -38,8 +39,17 @@ export function selectHandler(scrollbar: I.Scrollbar) {
     scroll(dir);
   });
 
-  addEvent(contentEl, 'selectstart', (evt: Event) => {
-    evt.stopPropagation();
+  // prevent scrolling when context menu is opened
+  addEvent(contentEl, 'contextmenu', () => {
+    isSelected = false;
+    isContextMenuOpened = true;
+  });
+
+  addEvent(contentEl, 'selectstart', () => {
+    if (isContextMenuOpened) {
+      return;
+    }
+
     cancelAnimationFrame(animationID);
 
     isSelected = true;
@@ -49,6 +59,7 @@ export function selectHandler(scrollbar: I.Scrollbar) {
     cancelAnimationFrame(animationID);
 
     isSelected = false;
+    isContextMenuOpened = false;
   });
 
   // patch for touch devices

--- a/src/events/select.ts
+++ b/src/events/select.ts
@@ -40,9 +40,17 @@ export function selectHandler(scrollbar: I.Scrollbar) {
   });
 
   // prevent scrolling when context menu is opened
+  // NOTE: `contextmenu` event may be fired
+  //          1. BEFORE `selectstart`: when user right-clicks on the text content -> prevent future scrolling,
+  //          2. AFTER `selectstart`: when user right-clicks on the blank area -> cancel current scrolling,
+  //        so we need to both set the flag and cancel current scrolling
   addEvent(contentEl, 'contextmenu', () => {
-    isSelected = false;
+    // set the flag to prevent future scrolling
     isContextMenuOpened = true;
+
+    // stop current scrolling
+    cancelAnimationFrame(animationID);
+    isSelected = false;
   });
 
   // reset context menu flag on mouse down


### PR DESCRIPTION
closes #489

## Description

This PR fixes the bug that drag-scrolling occurs after users right-click on the page and open the context menu (i.e. `contextmenu` event fires). 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
