### PR TITLE
fix: define `options.passive` as enumerable for compatibility

### DIFF
--- a/src/utils/event-hub.ts
+++ b/src/utils/event-hub.ts
@@ -24,8 +24,10 @@ function getOptions(): typeof eventListenerOptions {
   try {
     const noop = () => {};
     const options = Object.defineProperty({}, 'passive', {
+      enumerable: true,
       get() {
         supportPassiveEvent = true;
+        return true;
       },
     });
     window.addEventListener('testPassive', noop, options);


### PR DESCRIPTION
Fixes #519

## Description

In the `default-passive-event` package, they [copy the original event listener options](https://github.com/zzarcon/default-passive-events/blob/664c0d25cdb81a4f78f589321e613971e8279cf8/src/index.js#L18-L24) using `Object.assign({}, options)`. However, since we define the `options.passive` as non-enumerable property, this property will not be accessed in their monkey patch, and as a result, our code will assume that the browser does not support passive events according to the following detection procedure:

https://github.com/idiotWu/smooth-scrollbar/blob/02a0d8179eb5902ded0a022047b1634939f1908d/src/utils/event-hub.ts#L17-L38

This modification defines `options.passive` as `enumerable` to ensure compatibility with the `default-passive-event` package.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
