### PR TITLE
fix: remove debounce else return

### DIFF
--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -11,7 +11,6 @@ export function debounce<T extends (...args: any[]) => void>(fn: T, wait: number
       if (elapsed >= wait) {
         fn.apply(this, args);
       }
-    } else {
       return;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

IIRC refactoring debounce function, moving `return` to the else block was a mistake cause I think it block the `autoHideOnIdle` function call

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
