### PR TITLE
Add middle mouse button scrolling support

### DIFF
--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,4 +1,5 @@
 export * from './keyboard';
+export * from './middle-button';
 export * from './mouse';
 export * from './resize';
 export * from './select';

--- a/src/events/middle-button.ts
+++ b/src/events/middle-button.ts
@@ -1,0 +1,116 @@
+import * as I from '../interfaces/';
+import { eventScope, getPosition } from '../utils/';
+
+export function middleButtonHandler(scrollbar: I.Scrollbar) {
+  // Skip initialization if middle mouse scrolling is disabled
+  if (scrollbar.options.enableMiddleMouseScroll === false) {
+    return;
+  }
+
+  const addEvent = eventScope(scrollbar);
+  const container = scrollbar.containerEl;
+
+  let isAutoScrolling = false;
+  let clickPosition = { x: 0, y: 0 };
+  let animationID = 0;
+
+  function calculateScroll(currentPos: { x: number, y: number }): I.Data2d {
+    // Calculate distance from original click
+    const deltaX = currentPos.x - clickPosition.x;
+    const deltaY = currentPos.y - clickPosition.y;
+
+    // Dead zone radius
+    const deadZone = 5;
+
+    // Calculate distance
+    const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+
+    // If inside dead zone, don't scroll
+    if (distance < deadZone) {
+      return { x: 0, y: 0 };
+    }
+
+    // Simple scale factor for scroll speed
+    const factor = 0.2;
+
+    return {
+      x: deltaX * factor,
+      y: deltaY * factor,
+    };
+  }
+
+  function startAutoScrolling(pos: { x: number, y: number }) {
+    isAutoScrolling = true;
+    clickPosition = pos;
+
+    // Change cursor style to indicate auto-scrolling mode
+    document.body.style.cursor = 'all-scroll';
+
+    // Start scrolling loop
+    animationID = requestAnimationFrame(updateScroll);
+  }
+
+  function stopAutoScrolling() {
+    if (!isAutoScrolling) return;
+
+    isAutoScrolling = false;
+    cancelAnimationFrame(animationID);
+
+    // Restore default cursor
+    document.body.style.cursor = '';
+  }
+
+  function updateScroll() {
+    if (!isAutoScrolling) return;
+
+    // Calculate scroll amount
+    const { x, y } = calculateScroll(currentMousePos);
+
+    // Apply scroll
+    scrollbar.addMomentum(x, y);
+
+    // Continue scrolling
+    animationID = requestAnimationFrame(updateScroll);
+  }
+
+  // Store current mouse position
+  let currentMousePos = { x: 0, y: 0 };
+
+  // Track mouse position
+  addEvent(window, 'mousemove', (evt: MouseEvent) => {
+    currentMousePos = getPosition(evt);
+  });
+
+  // Handle mouse down
+  addEvent(container, 'mousedown', (evt: MouseEvent) => {
+    // If middle button
+    if (evt.button === 1) {
+      // Prevent default (which might be opening links in new tab)
+      evt.preventDefault();
+
+      // Toggle auto-scrolling
+      if (isAutoScrolling) {
+        stopAutoScrolling();
+      } else {
+        startAutoScrolling(getPosition(evt));
+      }
+    } else if (isAutoScrolling) {
+      // Any other mouse button stops auto-scrolling
+      stopAutoScrolling();
+    }
+  });
+
+  // Handle window blur
+  addEvent(window, 'blur', () => {
+    if (isAutoScrolling) {
+      stopAutoScrolling();
+    }
+  });
+
+  // Handle ESC key
+  addEvent(window, 'keydown', (evt: KeyboardEvent) => {
+    if (evt.key === 'Escape' && isAutoScrolling) {
+      stopAutoScrolling();
+    }
+  });
+}

--- a/src/events/middle-button.ts
+++ b/src/events/middle-button.ts
@@ -66,8 +66,12 @@ export function middleButtonHandler(scrollbar: I.Scrollbar) {
     // Calculate scroll amount
     const { x, y } = calculateScroll(currentMousePos);
 
-    // Apply scroll
-    scrollbar.addMomentum(x, y);
+    // Apply scroll with boundary checking
+    // Create a simple event to pass to the transformable momentum method
+    const mockEvent = new Event('middlemousescroll');
+    scrollbar.addTransformableMomentum(x, y, mockEvent, () => {
+      // No additional logic needed here
+    });
 
     // Continue scrolling
     animationID = requestAnimationFrame(updateScroll);

--- a/src/interfaces/scrollbar.ts
+++ b/src/interfaces/scrollbar.ts
@@ -35,6 +35,11 @@ export type ScrollbarOptions = {
    *  Delegate wheel events and touch events to the given element. By default, the container element is used. This option will be useful for dealing with fixed elements.
    * @default null
    */
+  enableMiddleMouseScroll: boolean,
+  /**
+   *  Delegate wheel events and touch events to the given element. By default, the container element is used. This option will be useful for dealing with fixed elements.
+   * @default null
+   */
   delegateTo: EventTarget | null,
   /**
    * @deprecated `wheelEventTarget` is deprecated and will be removed in the future, use `delegateTo` instead.

--- a/src/options.ts
+++ b/src/options.ts
@@ -43,6 +43,12 @@ export class Options {
   continuousScrolling = true;
 
   /**
+   * Enable middle mouse button scrolling
+   */
+  @boolean
+  enableMiddleMouseScroll = true;
+  
+  /**
    * Delegate wheel events and touch events to the given element.
    * By default, the container element is used.
    * This option will be useful for dealing with fixed elements.


### PR DESCRIPTION
## Description
This PR adds support for middle mouse button scrolling (auto-scrolling) that matches native browser behavior:

Users can click the middle mouse button to enter auto-scroll mode
Moving the mouse controls scroll direction and speed
Any mouse button click or ESC key exits auto-scroll mode
Cursor changes to 'all-scroll' during auto-scrolling to indicate the mode
Simple distance-based scrolling with a small dead zone for precision

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Added events/middle-button.ts with the implementation
Added export in events/index.ts
Added enableMiddleMouseScroll option (default: true) in options.ts
Updated interfaces/scrollbar.ts with the new option type
